### PR TITLE
fix: push only yml files to snowflake

### DIFF
--- a/src/commands/add-files-to-snowflake/add-snowflake-files-command.ts
+++ b/src/commands/add-files-to-snowflake/add-snowflake-files-command.ts
@@ -85,6 +85,11 @@ export class AddFilesToSnowflakeCommand extends Command {
 
     let { files } = await getFilesAndFolders(flags.source);
 
+    files = files.filter((fileName) => {
+      // filter for only yaml files
+      return fileName.endsWith(".yaml") || fileName.endsWith(".yml");
+    });
+
     files = files.map((fileName) => {
       return path.join(flags.source, fileName);
     });


### PR DESCRIPTION
A bug was found where an error occured when running the add-files-to-snowflake command twice, where snowflake creates a .log file and it throws an error when trying to push that file to snowflake.
Error is fixed by only pushing files that end with .yaml or .yml to Snowflake. 